### PR TITLE
TT-48: keep reports folder inside the app

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,8 +51,6 @@ jobs:
       - run: sudo apt-get update
       - run: sudo apt-get install xvfb libfontconfig wkhtmltopdf
 
-      - run: mkdir ./public/reports
-
       # Database setup
       - run: POSTGRES_DB="test_db" bundle exec rake db:create
       - run: bundle exec rake db:migrate

--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,7 @@
 !/log/.keep
 !/tmp/.keep
 
-/public/reports/*
+/public/reports/*.pdf
 
 # Ignore uploaded files in development
 /storage/*


### PR DESCRIPTION
https://trello.com/c/33yrAWxN/66-tt-48-mount-volume-for-reports-create-timereports-folder-during-the-creating-docker-image