### PR TITLE
TT-157: change start_time for time record only if the specific param was passed

### DIFF
--- a/app/controllers/v1/time_records_controller.rb
+++ b/app/controllers/v1/time_records_controller.rb
@@ -52,9 +52,13 @@ class V1::TimeRecordsController < V1::BaseController
       :assigned_date,
       tag_ids: []
     )
-    permitted_params.merge({
-      time_start: params[:start_task] ? Time.now : nil
-    })
+
+    unless params[:start_task].nil?
+      start_task_value = ActiveModel::Type::Boolean.new.cast(params[:start_task])
+      permitted_params[:time_start] = start_task_value ? Time.now : nil
+    end
+
+    return permitted_params
   end
 
   def time_record

--- a/spec/controllers/v1/time_records_controller_spec.rb
+++ b/spec/controllers/v1/time_records_controller_spec.rb
@@ -185,6 +185,23 @@ RSpec.describe V1::TimeRecordsController, type: :controller do
 
         travel_back
       end
+
+      it "should set start time as nil if spicific param for stopping issue was passed" do
+        travel_to Time.zone.local(2019, 10, 28)
+
+        put :update, params: { id: time_record.id, start_task: false, format: :json }
+        expect(time_record.reload.time_start).to be_nil
+
+        travel_back
+      end
+
+      it "shouldn't change start time if param for stopping issue was not passed" do
+        travel_to Time.zone.local(2019, 10, 28)
+
+        expect { put :update, params: { id: time_record.id,  format: :json } }.to_not change { time_record.time_start }
+
+        travel_back
+      end
     end
 
     context "params are invalid" do


### PR DESCRIPTION
https://trello.com/c/yiVDuMFm/157-remove-locking-time-record-for-changing-while-its-active