### PR TITLE
TT-111: do not send error if recover password process was launched for non-existed user

### DIFF
--- a/app/controllers/v1/users/passwords_controller.rb
+++ b/app/controllers/v1/users/passwords_controller.rb
@@ -4,12 +4,8 @@ class V1::Users::PasswordsController < V1::Users::BaseController
     validate_attribute_on_presence('email') and return
 
     user = User.find_by(email: params[:email])
-    if user.present?
-      UserMailer.recovery_password_email(user).deliver_now
-      render json: { status: 'ok' }, status: 200
-    else
-      render json: { errors: { base: I18n.t("passwords.user_not_found") } }, status: 404
-    end
+    UserMailer.recovery_password_email(user).deliver_now if user.present?
+    render json: { status: 'ok' }, status: 200
   end
 
   private

--- a/spec/controllers/v1/users/passwords_controller_spec.rb
+++ b/spec/controllers/v1/users/passwords_controller_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe V1::Users::PasswordsController, type: :controller do
 
     context "email was passed" do
       let!(:user) { create(:user) }
+      
       it "should send email if user was found" do
         mailer = double
         allow(User).to receive(:find_by) { user }
@@ -25,23 +26,9 @@ RSpec.describe V1::Users::PasswordsController, type: :controller do
         expect(response.body).to eq({ status: "ok" }.to_json)
       end
 
-      it "should return 400 status if user was found" do
+      it "should return 200 status if user was found" do
         post :create, params: { email: user.email, format: :json }
         expect(response.status).to eq(200)
-      end
-
-      it "should return error if user was not found" do
-        post :create, params: { email: "test@gmail.com", format: :json }
-        expect(response.body).to eq({
-          errors: {
-            base: I18n.t("passwords.user_not_found")
-          }
-        }.to_json)
-      end
-
-      it "should return 404 if user was not found" do
-        post :create, params: { email: "test@gmail.com", format: :json }
-        expect(response.status).to eq(404)
       end
     end
   end


### PR DESCRIPTION
https://trello.com/c/CpR1PmEJ/111-do-not-show-error-when-user-enters-a-wrong-email-on-the-forgot-password-page