### PR TITLE
TT-278: used specific attribute from params for understanding when start actions was raised

### DIFF
--- a/app/controllers/v1/time_records_controller.rb
+++ b/app/controllers/v1/time_records_controller.rb
@@ -46,6 +46,7 @@ class V1::TimeRecordsController < V1::BaseController
   def prepared_params
     params[:assigned_date] = params[:assigned_date].to_datetime if params[:assigned_date]
     permitted_params = params.permit(
+      :start_task,
       :project_id,
       :description,
       :spent_time,

--- a/app/forms/time_records/base_form.rb
+++ b/app/forms/time_records/base_form.rb
@@ -9,12 +9,12 @@ module TimeRecords
                  project_id user_id created_at updated_at tag_ids]
 
     attr_accessor *ATTRIBUTES
-    attr_accessor :id, :user, :time_record
+    attr_accessor :id, :user, :time_record, :start_task
 
     private
 
     def stop_other_launched_time_records
-      return if time_start.nil?
+      return unless start_task
       active_time_records = user.time_records.active.where("id <> ?", id)
       active_time_records.each(&:stop)
     end

--- a/spec/forms/time_records/create_form_spec.rb
+++ b/spec/forms/time_records/create_form_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe TimeRecords::CreateForm, type: :model do
         time_record = create(:time_record, user: user, time_start: Time.now)
         new_time_record = create(:time_record, user: user, time_start: Time.now)
 
-        time_record_form.time_start = Time.now
+        time_record_form.start_task = true
         allow(user).to receive_message_chain(:time_records, :create) { new_time_record }
         allow(user).to receive_message_chain(:time_records, :active, :where) { [time_record] }
         expect(time_record).to receive(:stop)

--- a/spec/forms/time_records/update_form_spec.rb
+++ b/spec/forms/time_records/update_form_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe TimeRecords::UpdateForm, type: :model do
         time_record = create(:time_record, user: user, time_start: Time.now)
         new_time_record = create(:time_record, user: user, time_start: Time.now)
 
-        time_record_form.time_start = Time.now
+        time_record_form.start_task = true 
         allow(user).to receive_message_chain(:time_records, :create) { new_time_record }
         allow(user).to receive_message_chain(:time_records, :active, :where) { [time_record] }
         expect(time_record).to receive(:stop)


### PR DESCRIPTION
https://trello.com/c/YnWh14Ln/278-timer-doesnt-respond-in-case-of-updating-active-time-record