### PR TITLE
TT-317: authorize user immediately after accepting invitation

### DIFF
--- a/app/controllers/v1/users/base_controller.rb
+++ b/app/controllers/v1/users/base_controller.rb
@@ -15,19 +15,20 @@ class V1::Users::BaseController < V1::BaseController
     if user
       user.assign_attributes(user_params)
       if user.save!
+        set_token(user)
         render json: { status: 'ok' }, status: 200
       else
         render json: { errors: user.errors }, status: 422
       end
     else
-      render json: { errors: { base: I18n.t("passwords.invalid_token") } }, status: 404
+      render json: { errors: { base: [I18n.t("passwords.invalid_token")] } }, status: 404
     end
   end
 
   def validate_attribute_on_presence(attribute)
     return false if params[attribute.to_sym].present?
     render(
-      json: { errors: { base: I18n.t("passwords.#{attribute}_does_not_present") } },
+      json: { errors: { base: [I18n.t("passwords.#{attribute}_does_not_present")] } },
       status: 400
     )
   end

--- a/spec/controllers/v1/users/passwords_controller_spec.rb
+++ b/spec/controllers/v1/users/passwords_controller_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe V1::Users::PasswordsController, type: :controller do
   describe "GET #new" do
     it "should return error in case of empty passed email" do
       post :create, params: { email: "", format: :json }
-      expect(response.body).to eq({ errors: { base:I18n.t("passwords.email_does_not_present") } }.to_json)
+      expect(response.body).to eq({ errors: { base: [I18n.t("passwords.email_does_not_present")] } }.to_json)
       expect(response.status).to eq(400)
     end
 
@@ -41,13 +41,13 @@ RSpec.describe V1::Users::PasswordsController, type: :controller do
   describe "PUT #update" do
     it "should return error in case of empty passed token" do
       put :update, params: { token: "", password: "", format: :json }
-      expect(response.body).to eql({ errors: { base: I18n.t("passwords.token_does_not_present") } }.to_json)
+      expect(response.body).to eq({ errors: { base: [I18n.t("passwords.token_does_not_present")] } }.to_json)
       expect(response.status).to eq(400)
     end
 
     it "should return error in case of empty passed password" do
       put :update, params: { token: "2222", password: "", format: :json }
-      expect(response.body).to eql({ errors: { base: I18n.t("passwords.password_does_not_present") } }.to_json)
+      expect(response.body).to eq({ errors: { base: [I18n.t("passwords.password_does_not_present")] } }.to_json)
       expect(response.status).to eq(400)
     end
 
@@ -81,6 +81,12 @@ RSpec.describe V1::Users::PasswordsController, type: :controller do
           expect(response.status).to eq(200)
         end
 
+        it 'should set token for user' do
+          expect(controller).to receive(:set_token).with(user)
+          allow(User).to receive(:find_by) { user }
+          put :update, params: request_params
+        end
+
         it "should return 422 status if user's password wasn't updated" do
           allow(User).to receive(:find_by) { user }
           allow(user).to receive(:save!) { false }
@@ -100,7 +106,7 @@ RSpec.describe V1::Users::PasswordsController, type: :controller do
       it "should return error message if token was expired" do
         allow(TokenCryptService).to receive(:decode).with("22222222") { nil }
         put :update, params: request_params
-        expect(response.body).to eq({ errors: { base: I18n.t("passwords.invalid_token") } }.to_json)
+        expect(response.body).to eq({ errors: { base: [I18n.t("passwords.invalid_token")] } }.to_json)
       end
     end
   end


### PR DESCRIPTION
https://trello.com/c/oexKfFir/317-log-in-user-after-the-accepting-invitation

also fixed problem with format of returning errors